### PR TITLE
Fix width bug and point-based features propagation bug

### DIFF
--- a/src/data/create_segments.py
+++ b/src/data/create_segments.py
@@ -44,6 +44,7 @@ def get_intersection_buffers(intersections, intersection_buffer_units):
 
     return unary_union(buffered_intersections)
 
+
 def find_non_ints(roads, int_buffers):
     """
     Find the segments that aren't intersections
@@ -131,7 +132,7 @@ def add_point_based_features(non_inters, inters, feats_filename=None,
         inters
         feats_filename - geojson file for point-based features data
     """
-    additional_feats_filename = None
+
     features = []
     if feats_filename:
         features = util.read_records_from_geojson(feats_filename)
@@ -451,6 +452,7 @@ if __name__ == '__main__':
         feats_file = None
     if not os.path.exists(additional_feats_file):
         additional_feats_file = None
+
     if feats_file or additional_feats_file:
         non_inters, inters = add_point_based_features(
             non_inters,

--- a/src/data/osm_create_maps.py
+++ b/src/data/osm_create_maps.py
@@ -220,6 +220,31 @@ def write_highway_keys(DOC_FP, highway_keys):
             w.writerow(item)
 
 
+def get_width(width):
+    """
+    Parse the width from the openstreetmap width property field
+    Args:
+        width - a string
+    Returns:
+        width - an int
+    """
+
+    # This indicates two segments combined together.
+    # For now, we just skip combined segments with different widths
+    if not width or ';' in width or '[' in width:
+        width = 0
+    else:
+        # Sometimes there's bad (non-numeric) width
+        # so remove anything that isn't a number or .
+        # Skip those that don't have some number in them
+        width = re.sub('[^0-9\.]+', '', width)
+        if width:
+            width = round(float(width))
+        else:
+            width = 0
+    return width
+
+
 def clean_ways(orig_file, DOC_FP):
     """
     Reads in osm_ways file, cleans up the features, and reprojects
@@ -257,21 +282,8 @@ def clean_ways(orig_file, DOC_FP):
         if not speed:
             speed = 0
 
-        # round width
-        width = 0
-        if 'width' in list(way_line['properties']):
-            width = way_line['properties']['width']
-            # This indicates two segments combined together
-            if not width or ';' in width or '[' in width:
-                width = 0
-            else:
-                width = re.sub('[^0-9]+', '', width)
-                # Sometimes there's bad (non-numeric) width
-                # If so, skip
-                if width:
-                    width = round(float(width))
-                else:
-                    width = 0
+        width = get_width(way_line['properties']['width']) \
+            if 'width' in list(way_line['properties']) else 0
 
         lanes = way_line['properties']['lanes']
         if lanes:

--- a/src/data/tests/test_osm_create_maps.py
+++ b/src/data/tests/test_osm_create_maps.py
@@ -5,6 +5,13 @@ from .. import osm_create_maps
 TEST_FP = os.path.dirname(os.path.abspath(__file__))
 
 
+def test_get_width():
+    assert osm_create_maps.get_width('15.2') == 15
+    assert osm_create_maps.get_width('') == 0
+    assert osm_create_maps.get_width("['14.9', '12.2']") == 0
+    assert osm_create_maps.get_width('t') == 0
+
+
 def test_reproject_and_clean_feats(tmpdir):
 
     tmppath = tmpdir.strpath


### PR DESCRIPTION
There are two bugs I'm fixing in this PR
- Create_segments wasn't adding the point-based features since I accidentally checked in the additional_feats_filename = None line during some testing. This causes the pipeline for cambridge to break when it can't find the feature. So taking that line back out
- When trying to do error handling on widths that didn't have any numbers in them (e.g. 't' which I found as a width in Somerville), I stripped out everything that wasn't a number, including decimal points. Fixed that, and wrote a test for the width processing.