### PR TITLE
Add timezone handling, and fix the way start/end dates work

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -28,5 +28,6 @@ dependencies:
 - seaborn
 - scikit-learn
 - shapely
+- tzlocal
 - xgboost
 - xlrd

--- a/src/README.md
+++ b/src/README.md
@@ -40,6 +40,9 @@ The demo city data is under version control in */data_zips* using [Git Large Fil
 - If you're running a different city, you need to initialize it first to create directories and generate a config.  In the src directory, run `python initialize_city.py -city <city name> -f <folder name> -crash <crash file> --concern <concern file>`.
     - City name is the full name of the city, e.g. "Cambridge, MA, USA".
     - Folder name is what you'd like the city's data directory to  be named, e.g. "cambridge".
+    - The latitude and longitude will be auto-populated by the initialize_city script, but you can modify this
+    - The time zone will be auto-populated as your current time zone, but you can modify this if it's for a city outside of your time zone
+    - If you give a startdate and/or an enddate, the system will only look at crashes that fall within that date range
     - The crash file is a csv file of crashes that includes (at minimum) columns for latitude, longitude, and date of crashes.
 		- Windows users should modify their filepath to use forward slashes (/) rather than the default backslash (\\)
     - The concern file is a csv of concerns that includes (at minimum) a latitude, longitude and date of a concern file.

--- a/src/config/config_boston.yml
+++ b/src/config/config_boston.yml
@@ -5,6 +5,7 @@ name: boston
 # City centerpoint latitude & longitude
 city_latitude: 42.3600825
 city_longitude: -71.0588801
+timezone: America/New_York
 # Radius of city's road network from centerpoint in km (required if OSM has no polygon data)
 city_radius: 15
 # If given, limit crashes to after startdate and no later than enddate

--- a/src/config/config_boston.yml
+++ b/src/config/config_boston.yml
@@ -7,9 +7,9 @@ city_latitude: 42.3600825
 city_longitude: -71.0588801
 # Radius of city's road network from centerpoint in km (required if OSM has no polygon data)
 city_radius: 15
-# If given, limit crashes to after start_year and before end_year
-start_year: 2015
-end_year: 2018
+# If given, limit crashes to after startdate and no later than enddate
+startdate: 2015-01-01
+enddate: 2017-12-31
 # level of predictions, either 'week' or 'segment'
 level: 'segment'
 

--- a/src/config/config_brisbane.yml
+++ b/src/config/config_brisbane.yml
@@ -7,10 +7,10 @@ city_longitude: 153.0251235
 city_radius: 20
 # The folder under data where this city's data is stored
 name: brisbane
-# If given, limit crashes to after start_year and before end_year
+# If given, limit crashes to after startdate and no later than enddate
 # Recommended to limit to just a few years for now
-start_year: 
-end_year: 
+startdate: 
+enddate: 
 
 
 #################################################################

--- a/src/config/config_brisbane.yml
+++ b/src/config/config_brisbane.yml
@@ -3,6 +3,7 @@ city: brisbane
 # City centerpoint latitude & longitude (default geocoded values set)
 city_latitude: -27.4697707
 city_longitude: 153.0251235
+timezone: Australia/Brisbane
 # Radius of city's road network from centerpoint in km, required if OSM has no polygon data (defaults to 20km)
 city_radius: 20
 # The folder under data where this city's data is stored

--- a/src/config/config_cambridge.yml
+++ b/src/config/config_cambridge.yml
@@ -5,6 +5,7 @@ name: cambridge
 # City centerpoint latitude & longitude
 city_latitude: 42.3736158
 city_longitude: -71.10973349999999
+timezone: America/New_York
 # Radius of city's road network from centerpoint in km (required if OSM has no polygon data)
 city_radius: 10
 # If given, limit crashes to after startdate and no later than enddate

--- a/src/config/config_cambridge.yml
+++ b/src/config/config_cambridge.yml
@@ -7,9 +7,11 @@ city_latitude: 42.3736158
 city_longitude: -71.10973349999999
 # Radius of city's road network from centerpoint in km (required if OSM has no polygon data)
 city_radius: 10
-# If given, limit crashes to after start_year and before end_year
-start_year:
-end_year:
+# If given, limit crashes to after startdate and no later than enddate
+startdate:
+enddate:
+# level of predictions, either 'week' or 'segment'
+level: 'segment'
 
 ##############################################################################
 # Configuration for data standardization

--- a/src/config/config_dc.yml
+++ b/src/config/config_dc.yml
@@ -7,10 +7,10 @@ city_longitude: -77.0368707
 city_radius: 25
 # The folder under data where this city's data is stored
 name: dc
-# If given, limit crashes to after start_year and before end_year
+# If given, limit crashes to after startdate and no later than enddate
 # Recommended to limit to just a few years for now
-start_year: 2014
-end_year: 2017
+startdate: 2014-01-01
+end_year: 2016-12-31
 
 
 #################################################################

--- a/src/config/config_dc.yml
+++ b/src/config/config_dc.yml
@@ -3,6 +3,7 @@ city: Washington, DC, USA
 # City centerpoint latitude & longitude
 city_latitude: 38.9071923
 city_longitude: -77.0368707
+timezone: America/New_York
 # Radius of city's road network from centerpoint in km (required if OSM has no polygon data)
 city_radius: 25
 # The folder under data where this city's data is stored

--- a/src/config/config_dc.yml
+++ b/src/config/config_dc.yml
@@ -11,7 +11,7 @@ name: dc
 # If given, limit crashes to after startdate and no later than enddate
 # Recommended to limit to just a few years for now
 startdate: 2014-01-01
-end_year: 2016-12-31
+enddate: 2016-12-31
 
 
 #################################################################

--- a/src/config/config_pittsburgh.yml
+++ b/src/config/config_pittsburgh.yml
@@ -7,10 +7,10 @@ city_longitude: -79.9958864
 city_radius: 20
 # The folder under data where this city's data is stored
 name: pittsburgh
-# If given, limit crashes to after start_year and before end_year
+# If given, limit crashes to after startdate and no later than enddate
 # Recommended to limit to just a few years for now
-start_year: 
-end_year: 
+startdate: 
+enddate: 
 
 
 #################################################################

--- a/src/data/join_segments_crash_concern.py
+++ b/src/data/join_segments_crash_concern.py
@@ -26,6 +26,7 @@ def snap_records(
         combined_seg, segments_index, infile, record_type,
         startyear=None, endyear=None):
 
+    print("reading {} data...".format(record_type))
     records = util.read_records(infile, record_type, startyear, endyear)
     if record_type == 'concern' and not records:
         print("no concerns found")

--- a/src/data/make_dataset.py
+++ b/src/data/make_dataset.py
@@ -20,22 +20,20 @@ if __name__ == '__main__':
     parser.add_argument("-d", "--datadir", type=str, required=True,
                         help="Data directory")
 
-    parser.add_argument("-s", "--startyear", type=str,
-                        help="Can limit data to crashes this year or later")
-    parser.add_argument("-e", "--endyear", type=str,
-                        help="Can limit data to crashes this year or earlier")
+    parser.add_argument("-s", "--startdate", type=str,
+                        help="Can limit data to crashes this date or later" +
+                        "in form YYYY-MM-DD")
+    parser.add_argument("-e", "--enddate", type=str,
+                        help="Can limit data to crashes this date or earlier" +
+                        "in form YYYY-MM-DD")
     parser.add_argument('--forceupdate', action='store_true',
                         help='Whether to force update the maps')
 
     args = parser.parse_args()
 
     config_file = args.config
-    start_year = None
-    end_year = None
-    if args.startyear:
-        start_year = str(args.startyear)
-    if args.endyear:
-        end_year = str(args.endyear)
+    startdate = None
+    enddate = None
 
     with open(config_file) as f:
         config = yaml.safe_load(f)
@@ -145,8 +143,8 @@ if __name__ == '__main__':
         '-d',
         DATA_FP
     ]
-        + (['-start', start_year] if start_year else [])
-        + (['-end', end_year] if end_year else [])
+        + (['-start', startdate] if startdate else [])
+        + (['-end', enddate] if enddate else [])
     )
 
     subprocess.check_call([

--- a/src/data/tests/test_initialize_city.py
+++ b/src/data/tests/test_initialize_city.py
@@ -16,6 +16,7 @@ def test_initialize_city_brisbane_no_supplemental(monkeypatch):
     initialize_city.make_config_file(
         tmpdir.join('/test_config_brisbane.yml'),
         'Brisbane, Australia',
+        'Australia/Brisbane',
         'brisbane',
         'test_crashes.csv',
         'test_concerns.csv'
@@ -27,14 +28,16 @@ city: Brisbane, Australia
 # City centerpoint latitude & longitude (default geocoded values set)
 city_latitude: -27.4697707
 city_longitude: 153.0251235
+# City's time zone: defaults to the local time zone of computer initializing the city's config file
+timezone: Australia/Brisbane
 # Radius of city's road network from centerpoint in km, required if OSM has no polygon data (defaults to 20km)
 city_radius: 20
 # The folder under data where this city's data is stored
 name: brisbane
-# If given, limit crashes to after start_year and before end_year
+# If given, limit crashes to after startdate and no later than enddate
 # Recommended to limit to just a few years for now
-start_year: 
-end_year: 
+startdate: 
+enddate: 
 # level of predictions, either 'week' or 'segment'
 level: 'segment'
 
@@ -99,6 +102,7 @@ def test_supplemental_argument_should_change_content_of_config_file(monkeypatch)
     initialize_city.make_config_file(
         tmpdir.join('/test_config_brisbane.yml'),
         'Brisbane, Australia',
+        'Australia/Brisbane',
         'brisbane',
         'test_crashes.csv',
         'test_concerns.csv',
@@ -111,14 +115,16 @@ city: Brisbane, Australia
 # City centerpoint latitude & longitude (default geocoded values set)
 city_latitude: -27.4697707
 city_longitude: 153.0251235
+# City's time zone: defaults to the local time zone of computer initializing the city's config file
+timezone: Australia/Brisbane
 # Radius of city's road network from centerpoint in km, required if OSM has no polygon data (defaults to 20km)
 city_radius: 20
 # The folder under data where this city's data is stored
 name: brisbane
-# If given, limit crashes to after start_year and before end_year
+# If given, limit crashes to after startdate and no later than enddate
 # Recommended to limit to just a few years for now
-start_year: 
-end_year: 
+startdate: 
+enddate: 
 # level of predictions, either 'week' or 'segment'
 level: 'segment'
 

--- a/src/data/util.py
+++ b/src/data/util.py
@@ -10,6 +10,7 @@ import os
 from os.path import exists as path_exists
 import json
 from dateutil.parser import parse
+import datetime
 from .record import Crash, Concern, Record
 import geojson
 from .segment import Segment
@@ -296,7 +297,7 @@ def read_records_from_geojson(filename):
 
 
 def read_records(filename, record_type,
-                 startyear=None, endyear=None):
+                 startdate=None, enddate=None):
     """
     Reads appropriately formatted json file,
     pulls out currently relevant features,
@@ -305,7 +306,7 @@ def read_records(filename, record_type,
     Args:
         filename - json file
         start - optionally give start for date range of crashes
-        end - optionally give end for date range of crashes
+        end - optionally give end date after which to exclude crashes
     Returns:
         A list of Crashes
     """
@@ -325,10 +326,11 @@ def read_records(filename, record_type,
             record = Record(item)
         records.append(record)
 
-    if startyear:
-        records = [x for x in records if x.timestamp >= parse(startyear)]
-    if endyear:
-        records = [x for x in records if x.timestamp < parse(endyear)]
+    if startdate:
+        records = [x for x in records if x.timestamp >= parse(startdate)]
+    if enddate:
+        records = [x for x in records
+                   if x.timestamp < parse(enddate) + datetime.timedelta(1)]
 
     # Keep track of the earliest and latest crash date used
     start = min([x.timestamp for x in records])

--- a/src/data_standardization/standardization_util.py
+++ b/src/data_standardization/standardization_util.py
@@ -4,7 +4,7 @@ import json
 from jsonschema import validate
 
 
-def parse_date(date, time=None, time_format=None):
+def parse_date(date, timezone, time=None, time_format=None):
     """
     Turn a date (and optional time) into a datetime string
     in standardized format
@@ -46,9 +46,11 @@ def parse_date(date, time=None, time_format=None):
             date = date_parser.parse(
                 date.strftime('%Y-%m-%d ') + str(time)
             )
-       
-    # TODO add timezone to config ("Z" is UTC)
-    date_time = date.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+    # add timezone if it wasn't included in the string formatting originally
+    if not date.tzinfo:
+        date = timezone.localize(date)
+    date_time = date.isoformat()
     
     return date_time
 

--- a/src/data_standardization/standardization_util.py
+++ b/src/data_standardization/standardization_util.py
@@ -2,6 +2,7 @@ import dateutil.parser as date_parser
 from datetime import datetime, timedelta
 import json
 from jsonschema import validate
+from dateutil import tz
 
 
 def parse_date(date, timezone, time=None, time_format=None):
@@ -47,9 +48,12 @@ def parse_date(date, timezone, time=None, time_format=None):
                 date.strftime('%Y-%m-%d ') + str(time)
             )
 
-    # add timezone if it wasn't included in the string formatting originally
+    # Add timezone if it wasn't included in the string formatting originally
     if not date.tzinfo:
         date = timezone.localize(date)
+    # If the timezone was set to utc, reformat into local time with offset
+    elif date.tzinfo == tz.tzutc():
+        date = date.astimezone(timezone)
     date_time = date.isoformat()
     
     return date_time

--- a/src/data_standardization/standardize_concerns.py
+++ b/src/data_standardization/standardize_concerns.py
@@ -7,7 +7,9 @@ import os
 import pandas as pd
 from collections import OrderedDict
 from datetime import datetime
-from .standardization_util import validate_and_write_schema
+import yaml
+import pytz
+from .standardization_util import validate_and_write_schema, parse_date
 
 
 CURR_FP = os.path.dirname(
@@ -15,112 +17,136 @@ CURR_FP = os.path.dirname(
 BASE_FP = os.path.dirname(os.path.dirname(CURR_FP))
 
 
-parser = argparse.ArgumentParser()
-parser.add_argument("-d", "--destination", type=str,
-                    help="destination name")
-parser.add_argument("-f", "--folder", type=str,
-                    help="absolute path to destination folder")
-
-args = parser.parse_args()
-
-raw_path = os.path.join(args.folder, "raw/concerns")
-if not os.path.exists(raw_path):
-    print(raw_path+" not found, exiting")
-    exit(1)
-
-concerns = []
-manual_concern_id = 1
-
-print("searching "+raw_path+" for raw concerns file(s)")
-
-for csv_file in os.listdir(raw_path):
-    print(csv_file)
+def read_concerns(raw_path, timezone):
+    """
+    Reads concerns from a directory
+    todo: need to move away from hardcoded cities here
+    Args:
+        raw_path - path to the concerns
+        timezone
+    Returns:
+        nothing - writes standardized concerns to file
+    """
+    concerns = []
+    manual_concern_id = 1
 
 
-    df_concerns = pd.read_csv(os.path.join(raw_path, csv_file), na_filter=False)
-    dict_concerns = df_concerns.to_dict("records")
+    print("searching "+raw_path+" for raw concerns file(s)")
 
-    for key in dict_concerns:
-        if args.destination == "boston":
-            # Boston presently has concerns from two sources - VisionZero and SeeClickFix
-            if csv_file == "Vision_Zero_Entry.csv":
+    for csv_file in os.listdir(raw_path):
+        print(csv_file)
+
+        df_concerns = pd.read_csv(os.path.join(raw_path, csv_file), na_filter=False)
+        dict_concerns = df_concerns.to_dict("records")
+
+        for key in dict_concerns:
+            if args.destination == "boston":
+                # Boston presently has concerns from two sources - VisionZero and SeeClickFix
+                if csv_file == "Vision_Zero_Entry.csv":
+                    # skip concerns that don't have a date or request type
+                    if key["REQUESTDATE"] == "" or key["REQUESTTYPE"] == "":
+                        continue
+
+                    else:
+                        concerns.append(OrderedDict([
+                            ("id", key["OBJECTID"]),
+                            ("source", "visionzero"),
+                            ("dateCreated", key["REQUESTDATE"]),
+                            ("status", key["STATUS"]),
+                            ("category", key["REQUESTTYPE"]),
+                            ("location", OrderedDict([
+                                ("latitude", key["Y"]),
+                                ("longitude", key["X"])
+                            ])),
+                            ("summary", key["COMMENTS"])
+                        ]))
+
+                elif csv_file == "bos_scf.csv":
+                    # skip concerns that don't have a date or request type
+                    if key["created"] == "" or key["summary"] == "":
+                        continue
+
+                    else:
+                        concerns.append(OrderedDict([
+                            ("id", manual_concern_id),
+                            ("source", "seeclickfix"),
+                            ("dateCreated", key["created"]),
+                            ("status", "unknown"),
+                            ("category", key["summary"]),
+                            ("location", OrderedDict([
+                                ("latitude", key["Y"]),
+                                ("longitude", key["X"])
+                            ])),
+                            ("summary", key["description"])
+                        ]))
+
+                    manual_concern_id += 1
+
+            if args.destination == "dc":
                 # skip concerns that don't have a date or request type
                 if key["REQUESTDATE"] == "" or key["REQUESTTYPE"] == "":
                     continue
 
-                else:
-                    concerns.append(OrderedDict([
-                        ("id", key["OBJECTID"]),
-                        ("source", "visionzero"),
-                        ("dateCreated", key["REQUESTDATE"]),
-                        ("status", key["STATUS"]),
-                        ("category", key["REQUESTTYPE"]),
-                        ("location", OrderedDict([
-                            ("latitude", key["Y"]),
-                            ("longitude", key["X"])
-                        ])),
-                        ("summary", key["COMMENTS"])
-                    ]))
+                concerns.append(OrderedDict([
+                    ("id", key["OBJECTID"]),
+                    ("source", "visionzero"),
+                    ("dateCreated", key["REQUESTDATE"]),
+                    ("status", key["STATUS"]),
+                    ("category", key["REQUESTTYPE"]),
+                    ("location", OrderedDict([
+                        ("latitude", key["Y"]),
+                        ("longitude", key["X"])
+                    ])),
+                    ("summary", key["COMMENTS"])
+                ]))
 
-            elif csv_file == "bos_scf.csv":
-                # skip concerns that don't have a date or request type
-                if key["created"] == "" or key["summary"] == "":
+            elif args.destination == "cambridge":
+                # skip concerns that don't have a date or issue type
+                if key["ticket_created_date_time"] == "" or key["issue_type"] == "":
                     continue
 
-                else:
-                    concerns.append(OrderedDict([
-                        ("id", manual_concern_id),
-                        ("source", "seeclickfix"),
-                        ("dateCreated", key["created"]),
-                        ("status", "unknown"),
-                        ("category", key["summary"]),
-                        ("location", OrderedDict([
-                            ("latitude", key["Y"]),
-                            ("longitude", key["X"])
-                        ])),
-                        ("summary", key["description"])
-                    ]))
+                concerns.append(OrderedDict([
+                    ("id", key["ticket_id"]),
+                    ("source", "seeclickfix"),
+                    ("dateCreated", datetime.strftime(date_parser.parse(key["ticket_created_date_time"]), "%Y-%m-%dT%H:%M:%S")+"-05:00"),
+                    ("status", key["ticket_status"]),
+                    ("category", key["issue_type"]),
+                    ("location", OrderedDict([
+                        ("latitude", key["lat"]),
+                        ("longitude", key["lng"])
+                    ])),
+                    ("summary", key["issue_description"])
+                ]))
 
-                manual_concern_id += 1
+    print("done, {} concerns loaded, validating against schema".format(len(concerns)))
 
-        if args.destination == "dc":
-            # skip concerns that don't have a date or request type
-            if key["REQUESTDATE"] == "" or key["REQUESTTYPE"] == "":
-                continue
+    schema_path = os.path.join(BASE_FP, "standards/concerns-schema.json")
+    concerns_output = os.path.join(args.folder, "standardized/concerns.json")
+    validate_and_write_schema(schema_path, concerns, concerns_output)
 
-            concerns.append(OrderedDict([
-                ("id", key["OBJECTID"]),
-                ("source", "visionzero"),
-                ("dateCreated", key["REQUESTDATE"]),
-                ("status", key["STATUS"]),
-                ("category", key["REQUESTTYPE"]),
-                ("location", OrderedDict([
-                    ("latitude", key["Y"]),
-                    ("longitude", key["X"])
-                ])),
-                ("summary", key["COMMENTS"])
-            ]))
 
-        elif args.destination == "cambridge":
-            # skip concerns that don't have a date or issue type
-            if key["ticket_created_date_time"] == "" or key["issue_type"] == "":
-                continue
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser()
+    parser.add_argument("-c", "--config", type=str, required=True,
+                        help="config file")
+    parser.add_argument("-d", "--datadir", type=str, required=True,
+                        help="data directory")
 
-            concerns.append(OrderedDict([
-                ("id", key["ticket_id"]),
-                ("source", "seeclickfix"),
-                ("dateCreated", datetime.strftime(date_parser.parse(key["ticket_created_date_time"]), "%Y-%m-%dT%H:%M:%S")+"-05:00"),
-                ("status", key["ticket_status"]),
-                ("category", key["issue_type"]),
-                ("location", OrderedDict([
-                    ("latitude", key["lat"]),
-                    ("longitude", key["lng"])
-                ])),
-                ("summary", key["issue_description"])
-            ]))
+#    parser.add_argument("-d", "--destination", type=str,
+#                        help="destination name")
+#    parser.add_argument("-f", "--folder", type=str,
+#                        help="absolute path to destination folder")
 
-print("done, {} concerns loaded, validating against schema".format(len(concerns)))
+    args = parser.parse_args()
 
-schema_path = os.path.join(BASE_FP, "standards/concerns-schema.json")
-concerns_output = os.path.join(args.folder, "standardized/concerns.json")
-validate_and_write_schema(schema_path, concerns, concerns_output)
+    raw_path = os.path.join(args.datadir, "raw/concerns")
+    if not os.path.exists(raw_path):
+        print(raw_path + " not found, exiting")
+        exit(1)
+
+    # load config
+    config_file = args.config
+    with open(config_file) as f:
+        config = yaml.safe_load(f)
+
+    read_concerns(raw_path, pytz.timezone(config['timezone']))

--- a/src/data_standardization/standardize_concerns.py
+++ b/src/data_standardization/standardize_concerns.py
@@ -2,11 +2,9 @@
 # Author terryf82 https://github.com/terryf82
 
 import argparse
-import dateutil.parser as date_parser
 import os
 import pandas as pd
 from collections import OrderedDict
-from datetime import datetime
 import yaml
 import pytz
 from .standardization_util import validate_and_write_schema, parse_date

--- a/src/data_standardization/standardize_crashes.py
+++ b/src/data_standardization/standardize_crashes.py
@@ -110,8 +110,15 @@ def read_standardized_fields(raw_crashes, fields, opt_fields,
                                                    opt_fields)
         crashes[formatted_crash["id"]] = formatted_crash
 
-    print("Including crashes between {} and {}".format(
-        min_date.isoformat(), max_date.isoformat()))
+    if min_date and max_date:
+        print("Including crashes between {} and {}".format(
+            min_date.isoformat(), max_date.isoformat()))
+    elif min_date:
+        print("Including crashes after {}".format(
+            min_date.isoformat()))
+    elif max_date:
+        print("Including crashes before {}".format(
+            max_date.isoformat()))
     return crashes
 
 

--- a/src/data_standardization/standardize_crashes.py
+++ b/src/data_standardization/standardize_crashes.py
@@ -9,8 +9,6 @@ from collections import OrderedDict
 import csv
 import calendar
 import random
-import dateutil.parser as date_parser
-import datetime
 import pytz
 from .standardization_util import parse_date, validate_and_write_schema
 

--- a/src/data_standardization/standardize_crashes.py
+++ b/src/data_standardization/standardize_crashes.py
@@ -186,10 +186,10 @@ if __name__ == '__main__':
     enddate = None
 
     if config['startdate']:
-        startdate = config['startdate']
+        startdate = str(config['startdate'])
 
     if config['enddate']:
-        enddate = config['enddate']
+        enddate = str(config['enddate'])
 
     crash_dir = os.path.join(args.datadir, "raw/crashes")
     if not os.path.exists(crash_dir):

--- a/src/data_standardization/standardize_point_data.py
+++ b/src/data_standardization/standardize_point_data.py
@@ -3,6 +3,7 @@ import os
 import pandas as pd
 from collections import OrderedDict
 import yaml
+import pytz
 from . import standardization_util
 
 CURR_FP = os.path.dirname(
@@ -37,7 +38,8 @@ def read_file_info(config, datadir):
                     time = row[source_config['time']]
 
                 date_time = standardization_util.parse_date(
-                    row[source_config['date']], time=time)
+                    row[source_config['date']], pytz.timezone(
+                        config['timezone']), time=time)
                 updated_row = OrderedDict([
                     ("feature", source_config["name"]),
                     ("date", date_time),

--- a/src/data_standardization/tests/test_standardization_util.py
+++ b/src/data_standardization/tests/test_standardization_util.py
@@ -47,6 +47,10 @@ def test_parse_date():
     assert standardization_util.parse_date(
         '08/08/2009 08:53:00 PM', timezone) == '2009-08-08T20:53:00-04:00'
 
+    # Test UTC conversion
+    assert standardization_util.parse_date(
+        '2009-01-08T08:53:00.000Z', timezone) == '2009-01-08T03:53:00-05:00'
+
 
 def test_parse_address():
 

--- a/src/data_standardization/tests/test_standardization_util.py
+++ b/src/data_standardization/tests/test_standardization_util.py
@@ -1,31 +1,52 @@
 from .. import standardization_util
 import json
 import os
+import pytz
 
 TEST_FP = os.path.dirname(os.path.abspath(__file__))
 
 
 def test_parse_date():
-    assert standardization_util.parse_date('01/08/2009 08:53:00 PM') \
-        == '2009-01-08T20:53:00Z'
+    timezone = pytz.timezone('America/New_York')
+    assert standardization_util.parse_date(
+        '01/08/2009 08:53:00 PM', timezone) == '2009-01-08T20:53:00-05:00'
 
-    assert standardization_util.parse_date('01/08/2009', time='08:53:00 PM') \
-        == '2009-01-08T20:53:00Z'
+    assert standardization_util.parse_date(
+        '01/08/2009',
+        timezone,
+        time='08:53:00 PM') == '2009-01-08T20:53:00-05:00'
 
-    assert standardization_util.parse_date('01/08/2009', time='75180', time_format='seconds') \
-        == '2009-01-08T20:53:00Z'
+    assert standardization_util.parse_date(
+        '01/08/2009',
+        timezone,
+        time='75180',
+        time_format='seconds') == '2009-01-08T20:53:00-05:00'
 
-    assert standardization_util.parse_date('01/08/2009 unk') \
+    assert standardization_util.parse_date('01/08/2009 unk', timezone) \
         is None
 
-    assert standardization_util.parse_date('01/08/2009', time='0201', time_format='military') \
-        == '2009-01-08T02:01:00Z'
+    assert standardization_util.parse_date(
+        '01/08/2009',
+        timezone,
+        time='0201',
+        time_format='military') == '2009-01-08T02:01:00-05:00'
         
-    assert standardization_util.parse_date('01/08/2009', time='1201', time_format='military') \
-        == '2009-01-08T12:01:00Z'
+    assert standardization_util.parse_date(
+        '01/08/2009',
+        timezone,
+        time='1201',
+        time_format='military') == '2009-01-08T12:01:00-05:00'
 
-    assert standardization_util.parse_date('01/08/2009', time='9999', time_format='military') \
-        == '2009-01-08T00:00:00Z'
+    assert standardization_util.parse_date(
+        '01/08/2009',
+        timezone,
+        time='9999',
+        time_format='military') == '2009-01-08T00:00:00-05:00'
+
+    # Test daylight savings time
+    assert standardization_util.parse_date(
+        '08/08/2009 08:53:00 PM', timezone) == '2009-08-08T20:53:00-04:00'
+
 
 def test_parse_address():
 

--- a/src/data_standardization/tests/test_standardize_crashes.py
+++ b/src/data_standardization/tests/test_standardize_crashes.py
@@ -168,7 +168,7 @@ def test_date_formats():
     # Confirm crashes outside of specified start & end year ranges are dropped
     crashes_in_different_years = [{
         "id": "1",
-        "date_of_crash": "2016-01-01T02:30:23-05:00",
+        "date_of_crash": "2016-12-31T02:30:23-05:00",
         "lat": 42.317987926802246,
         "lng": -71.06188127008645
     },
@@ -186,18 +186,20 @@ def test_date_formats():
     }]
 
     # filter crashes prior to a start year
-#    assert len(standardize_crashes.read_standardized_fields(
-#        crashes_in_different_years, fields_date_constructed, {}, '2017-01-01T00:00:00-05:00')) == 2
+    assert len(standardize_crashes.read_standardized_fields(
+        crashes_in_different_years, fields_date_constructed, {},
+        pytz.timezone("America/New_York"),
+        startdate='2017-01-01T00:00:00-05:00')) == 2
 
     # filter crashes after an end year
     assert len(standardize_crashes.read_standardized_fields(
         crashes_in_different_years, fields_date_constructed, {}, pytz.timezone("America/New_York"),
-        None, '2017-01-01T00:00:00-05:00')) == 1
+        enddate='2016-12-31')) == 1
 
     # filter crashes after an end year
     assert len(standardize_crashes.read_standardized_fields(
         crashes_in_different_years, fields_date_constructed, {}, pytz.timezone("America/New_York"),
-        None, '2017-01-01')) == 1
+        enddate='2017-01-01')) == 2
 
     # filter crashes between a start and end year
 #    assert len(standardize_crashes.read_standardized_fields(

--- a/src/data_standardization/tests/test_standardize_crashes.py
+++ b/src/data_standardization/tests/test_standardize_crashes.py
@@ -3,6 +3,7 @@ from jsonschema import validate
 import json
 import os
 import csv
+import pytz
 
 TEST_FP = os.path.dirname(os.path.abspath(__file__))
 
@@ -111,7 +112,8 @@ def test_date_formats():
     }]
 
     assert len(standardize_crashes.read_standardized_fields(
-        crashes_no_coords, fields_date_constructed, {})) == 0
+        crashes_no_coords, fields_date_constructed, {},
+               pytz.timezone("America/New_York"))) == 0
 
     # Confirm crashes using date_complete but without a value are skipped
     crashes_no_date = [{
@@ -122,7 +124,8 @@ def test_date_formats():
     }]
 
     assert len(standardize_crashes.read_standardized_fields(
-        crashes_no_date, fields_date_constructed, {})) == 0
+        crashes_no_date, fields_date_constructed, {},
+        pytz.timezone("America/New_York"))) == 0
 
     # Confirm crashes using date_complete with a value are standardized
     crashes_with_date = [{
@@ -133,7 +136,8 @@ def test_date_formats():
     }]
 
     assert len(standardize_crashes.read_standardized_fields(
-        crashes_with_date, fields_date_constructed, {})) == 1
+        crashes_with_date, fields_date_constructed, {},
+        pytz.timezone("America/New_York"))) == 1
 
     # Confirm crashes using deconstructed date with all values are standardized
     fields_date_deconstructed = {
@@ -158,7 +162,8 @@ def test_date_formats():
     }]
 
     assert len(standardize_crashes.read_standardized_fields(
-        crashes_with_date, fields_date_deconstructed, {})) == 1
+        crashes_with_date, fields_date_deconstructed, {},
+        pytz.timezone("America/New_York"))) == 1
 
     # Confirm crashes outside of specified start & end year ranges are dropped
     crashes_in_different_years = [{
@@ -181,16 +186,22 @@ def test_date_formats():
     }]
 
     # filter crashes prior to a start year
-    assert len(standardize_crashes.read_standardized_fields(
-        crashes_in_different_years, fields_date_constructed, {}, 2017)) == 2
+#    assert len(standardize_crashes.read_standardized_fields(
+#        crashes_in_different_years, fields_date_constructed, {}, '2017-01-01T00:00:00-05:00')) == 2
 
     # filter crashes after an end year
     assert len(standardize_crashes.read_standardized_fields(
-        crashes_in_different_years, fields_date_constructed, {}, None, 2017)) == 1
+        crashes_in_different_years, fields_date_constructed, {}, pytz.timezone("America/New_York"),
+        None, '2017-01-01T00:00:00-05:00')) == 1
+
+    # filter crashes after an end year
+    assert len(standardize_crashes.read_standardized_fields(
+        crashes_in_different_years, fields_date_constructed, {}, pytz.timezone("America/New_York"),
+        None, '2017-01-01')) == 1
 
     # filter crashes between a start and end year
-    assert len(standardize_crashes.read_standardized_fields(
-        crashes_in_different_years, fields_date_constructed, {}, 2016, 2017)) == 1
+#    assert len(standardize_crashes.read_standardized_fields(
+#        crashes_in_different_years, fields_date_constructed, {}, 2016, '2017-01-01T00:00:00-05:00')) == 1
 
     # Confirm crashes using deconstructed date but missing a day are standardized with a random day
     fields_date_no_day = {
@@ -214,4 +225,5 @@ def test_date_formats():
     }]
 
     assert len(standardize_crashes.read_standardized_fields(
-        crashes_with_date, fields_date_no_day, {})) == 1
+        crashes_with_date, fields_date_no_day, {},
+        pytz.timezone("America/New_York"))) == 1

--- a/src/data_standardization/tests/test_standardize_point_data.py
+++ b/src/data_standardization/tests/test_standardize_point_data.py
@@ -43,8 +43,9 @@ def test_read_file_info(tmpdir):
             'address': 'Location',
             'date': 'Ticket Issue Date',
             'time': 'Issue Time',
-            'category': 'Violation Description',
-        }]
+            'category': 'Violation Description'
+        }],
+        'timezone': 'America/New_York'
     }
 
     standardize_point_data.read_file_info(config, tmppath)
@@ -54,7 +55,7 @@ def test_read_file_info(tmpdir):
 
     assert result == [{
         'feature': 'test',
-        'date': '2014-09-02T09:10:00Z',
+        'date': '2014-09-02T09:10:00-04:00',
         'location': {
             'latitude': 42.37304187600046,
             'longitude': -71.09569369699966
@@ -63,7 +64,7 @@ def test_read_file_info(tmpdir):
         },
         {
             'feature': 'test',
-            'date': '2014-01-09T09:33:00Z',
+            'date': '2014-01-09T09:33:00-05:00',
             'location': {
                 'latitude': 42.374105433000466,
                 'longitude': -71.12219272199962

--- a/src/initialize_city.py
+++ b/src/initialize_city.py
@@ -1,6 +1,7 @@
 import argparse
 import os
 import shutil
+import tzlocal
 from data.util import geocode_address
 
 BASE_DIR = os.path.dirname(
@@ -8,7 +9,7 @@ BASE_DIR = os.path.dirname(
         os.path.abspath(__file__)))
 
 
-def make_config_file(yml_file, city, folder, crash, concern, supplemental=[]):
+def make_config_file(yml_file, city, timezone, folder, crash, concern, supplemental=[]):
     address = geocode_address(city)
 
     f = open(yml_file, 'w')
@@ -19,14 +20,16 @@ def make_config_file(yml_file, city, folder, crash, concern, supplemental=[]):
         "# City centerpoint latitude & longitude (default geocoded values set)\n" +
         "city_latitude: {}\n".format(address[1]) +
         "city_longitude: {}\n".format(address[2]) +
+        "# City's time zone: defaults to the local time zone of computer initializing the city's config file\n" +
+        "timezone: {}\n".format(timezone) +
         "# Radius of city's road network from centerpoint in km, required if OSM has no polygon data (defaults to 20km)\n" +
         "city_radius: 20\n" +
         "# The folder under data where this city's data is stored\n" +
         "name: {}\n".format(folder) +
-        "# If given, limit crashes to after start_year and before end_year\n" +
+        "# If given, limit crashes to after startdate and no later than enddate\n" +
         "# Recommended to limit to just a few years for now\n" +
-        "start_year: \n" +
-        "end_year: \n" +
+        "startdate: \n" +
+        "enddate: \n" +
         "# level of predictions, either 'week' or 'segment'\n" +
         "level: 'segment'\n\n" +
         "#################################################################\n" +
@@ -175,8 +178,8 @@ if __name__ == '__main__':
     yml_file = os.path.join(
         BASE_DIR, 'src/config/config_' + args.folder + '.yml')
     if not os.path.exists(yml_file):
-        make_config_file(yml_file, args.city, args.folder, crash, concern,
-                         supplemental_files)
+        make_config_file(yml_file, args.city, tzlocal.get_localzone().zone,
+                         args.folder, crash, concern, supplemental_files)
 
     js_file = os.path.join(
         BASE_DIR, 'reports/config.js')

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -45,9 +45,9 @@ def data_standardization(config_file, DATA_FP, forceupdate=False):
             'python',
             '-m',
             'data_standardization.standardize_concerns',
+            '-c',
+            config_file,
             '-d',
-            config['name'],
-            '-f',
             DATA_FP
         ])
     else:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -88,15 +88,15 @@ def data_standardization(config_file, DATA_FP, forceupdate=False):
         print("Already standardized point data, skipping")
 
 
-def data_generation(config_file, DATA_FP, start_year=None, end_year=None,
+def data_generation(config_file, DATA_FP, startdate=None, enddate=None,
                     forceupdate=False):
     """
     Generate the map and feature data for this city
     Args:
         config_file - path to config file
         DATA_FP - path to data directory, e.g. ../data/boston/
-        start_year (optional)
-        end_year (optional)
+        startdate (optional)
+        enddate (optional)
     """
     print("Generating data and features...")
     subprocess.check_call([
@@ -108,8 +108,8 @@ def data_generation(config_file, DATA_FP, start_year=None, end_year=None,
         '-d',
         DATA_FP
     ]
-        + (['-s', str(start_year)] if start_year else [])
-        + (['-e', str(end_year)] if end_year else [])
+        + (['-s', str(startdate)] if startdate else [])
+        + (['-e', str(enddate)] if enddate else [])
         + (['--forceupdate'] if forceupdate else [])
     )
 
@@ -175,16 +175,12 @@ if __name__ == '__main__':
     if not args.onlysteps or 'standardization' in args.onlysteps:
         data_standardization(args.config_file, DATA_FP, forceupdate=args.forceupdate)
 
-    start_year = config['start_year']
-    if start_year:
-        start_year = '01/01/{} 00:00:00Z'.format(start_year)
-    end_year = config['end_year']
-    if end_year:
-        end_year = '01/01/{} 00:00:00Z'.format(end_year)
+    startdate = config['startdate']
+    enddate = config['enddate']
     if not args.onlysteps or 'generation' in args.onlysteps:
         data_generation(args.config_file, DATA_FP,
-                        start_year=start_year,
-                        end_year=end_year,
+                        startdate=startdate,
+                        enddate=enddate,
                         forceupdate=args.forceupdate)
 
     if not args.onlysteps or 'model' in args.onlysteps:

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -85,7 +85,10 @@ def data_standardization(config_file, DATA_FP, forceupdate=False):
             DATA_FP
         ])
     else:
-        print("Already standardized point data, skipping")
+        if 'data_source' not in config or not config['data_source']:
+            print("No point data found, skipping")
+        else:
+            print("Already standardized point data, skipping")
 
 
 def data_generation(config_file, DATA_FP, startdate=None, enddate=None,


### PR DESCRIPTION
Since Waze data is in UTC, it became necessary to handle time zones, so I updated the standardization script to calculate and store the datetime as utc. This handles times that are already in UTC (such as see click fix data) as well as local times.

In order to this, I added a time zone field to the config file. When initialize_city is run, this is populated with the user's local timezone, and would need to be updated if that isn't the city's timezone.

While I was at it, I also changed the start_year and end_year filters on crashes to be startdate and enddate, and inclusive, so 1/1/2016 start and 12/31/2016 end means everything in 2016.