### PR TITLE
Fixing warnings that occur during model step 

### DIFF
--- a/src/models/model_classes.py
+++ b/src/models/model_classes.py
@@ -102,7 +102,7 @@ class Tuner():
                     model(),scoring=cvparams['pmetric'], 
                     cv = KFold(cvparams['folds'], cvparams['shuffle']),
                     refit=False, n_iter=cvparams['iter'],
-                    param_distributions=mparams, verbose=1)
+                    param_distributions=mparams, verbose=1, return_train_score=True)
         return(grid)
     
     def run_grid(self, grid, train_x, train_y):

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -69,7 +69,6 @@ def set_params():
     mp['LogisticRegression']['C'] = ss.beta(a=5,b=2) #beta distribution for selecting reg strength
     mp['LogisticRegression']['class_weight'] = ['balanced']
     mp['LogisticRegression']['solver'] = ['liblinear']
-    mp['LogisticRegression']['max_iter'] = [110]
 
     #xgBoost model parameters
     mp['XGBClassifier'] = dict()

--- a/src/models/train_model.py
+++ b/src/models/train_model.py
@@ -68,6 +68,8 @@ def set_params():
     mp['LogisticRegression']['penalty'] = ['l1','l2']
     mp['LogisticRegression']['C'] = ss.beta(a=5,b=2) #beta distribution for selecting reg strength
     mp['LogisticRegression']['class_weight'] = ['balanced']
+    mp['LogisticRegression']['solver'] = ['liblinear']
+    mp['LogisticRegression']['max_iter'] = [110]
 
     #xgBoost model parameters
     mp['XGBClassifier'] = dict()


### PR DESCRIPTION
Warning 1:
```FutureWarning: You are accessing a training score ('split0_train_score'), which will not be available by default any more in 0.21.```

- set return_train_score=True for RandomizedSearchCV model

Warning 2:
```FutureWarning: Default solver will be changed to 'lbfgs' in 0.22. Specify a solver to silence this warning```

- set a default solver to liblinear since it works with both L1 and L2 type of penalties.
(Had tried lgbfs solver as well, but that does not work with L1. Also for that, I had to increase number of iterations, otherwise it started giving a separate warning regarding non convergence)